### PR TITLE
Dependencies: support QuantumOptics 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ NLsolve = "4.5.1"
 OrderedCollections = "1.4.1"
 PolynomialRoots = "1.0.0"
 QuantumOptics = "0.8.0, 1"
-WignerSymbols = "1.0.0"
+WignerSymbols = "1.0.0, 2"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ FunctionWrappers = "1.1.2"
 NLsolve = "4.5.1"
 OrderedCollections = "1.4.1"
 PolynomialRoots = "1.0.0"
-QuantumOptics = "0.8.0"
+QuantumOptics = "0.8.0, 1"
 WignerSymbols = "1.0.0"
 
 [extras]

--- a/src/time_evolution.jl
+++ b/src/time_evolution.jl
@@ -1,21 +1,20 @@
 import QuantumOptics.timeevolution
 import QuantumOptics.stochastic
 using QuantumOptics: Basis, Operator, CompositeBasis, Ket, StateVector
-using QuantumOptics.timeevolution: DecayRates
 
 #############################################################################################
 # Wrap QuantumOptics solvers in order to implement our form of basis check
 #############################################################################################
 
 # function timeevolution.master_dynamic(tspan, rho0::T, f::Function;
-#             rates::DecayRates=nothing, fout::Union{Function,Nothing}=nothing, kwargs...
+#             rates=nothing, fout::Union{Function,Nothing}=nothing, kwargs...
 #         ) where {B<:Basis,T<:Operator{B,B}}
 #     check_bases(f(0., 0.).basis_l, rho0.basis_l)
 #     timeevolution.master_dynamic(tspan, rho0, f; rates=rates, fout=fout, kwargs...)
 # end
 
 # function timeevolution.mcwf_dynamic(tspan, psi0::T, f::Function;
-#     seed=rand(UInt), rates::DecayRates=nothing,
+#     seed=rand(UInt), rates=nothing,
 #     fout=nothing, display_beforeevent=false, display_afterevent=false,
 #     kwargs...) where {T<:Ket}
 #     check_bases(f(0., 0.).basis_l, psi0.basis)
@@ -37,7 +36,7 @@ using QuantumOptics.timeevolution: DecayRates
 # end
 
 # function stochastic.master_dynamic(tspan, rho0::T, fdeterm::Function, fstoch::Function;
-#             rates::DecayRates=nothing, fout::Union{Function,Nothing}=nothing,
+#             rates=nothing, fout::Union{Function,Nothing}=nothing,
 #             noise_processes::Int=0, kwargs...
 #         ) where {B<:Basis,T<:Operator{B,B}}
 #         check_bases()


### PR DESCRIPTION
# Motivation
From a clean install of Julia 1.7, was trying to create an environment but was running into compilation errors with the resolved dependency set.
Decided to resolve this dependency issue by loosening the QuantumOptics dependency requirements. This compiles cleanly locally, and tests pass


## Commits:

﻿- time_evolution: compatibility with QuantumOptics >= 1.0.0
- dependencies: compatibility with WignerSymbols 2.0
