### PR TITLE
Multiple species in same ionchain

### DIFF
--- a/src/ion_configurations.jl
+++ b/src/ion_configurations.jl
@@ -183,7 +183,7 @@ struct LinearChain <: IonConfiguration  # Note: this is not a mutable struct
         for (i, modes) in enumerate(vibrational_modes), mode in modes
             push!(vm[i], VibrationalMode(A[i][mode]..., axis = r[i]))
         end
-        l = linear_equilibrium_positions(length(ions), mass.(ions))
+        l = linear_equilibrium_positions(length(ions), Tuple(mass.(ions)))
         # Use the mass of only the first ion to define the characteristic length scale.
         l0 = characteristic_length_scale(mass(ions[1]), com_frequencies.z)
         for (i, ion) in enumerate(ions)

--- a/src/ion_configurations.jl
+++ b/src/ion_configurations.jl
@@ -34,13 +34,18 @@ If the mass list is shorter than the number of ions, it is assumed to repeat;
 i.e. (M_a, M_b) corresponds to (M_a, M_b, M_a, M_b, ...).
 [ref](https://doi.org/10.1007/s003400050373)
 """
-function linear_equilibrium_positions(N::Int, masslist::NTuple{num, Real} = (1.0,)) where {num}
-    relativemasslist = masslist./masslist[1]
+function linear_equilibrium_positions(
+    N::Int,
+    masslist::NTuple{num, Real} = (1.0,)
+) where {num}
+    relativemasslist = masslist ./ masslist[1]
     masslistlength = length(relativemasslist)
     function f!(F, x, N, masses, masseslength)
         for i in 1:N
             F[i] = (
-                masses[(i-1) % masseslength + 1] * x[i] - sum([1 / (x[i] - x[j])^2 for j in 1:(i - 1)]) + sum([1 / (x[i] - x[j])^2 for j in (i + 1):N])
+                masses[(i - 1) % masseslength + 1] * x[i] -
+                sum([1 / (x[i] - x[j])^2 for j in 1:(i - 1)]) +
+                sum([1 / (x[i] - x[j])^2 for j in (i + 1):N])
             )
         end
     end
@@ -49,7 +54,9 @@ function linear_equilibrium_positions(N::Int, masslist::NTuple{num, Real} = (1.0
         for i in 1:N, j in 1:N
             if i ≡ j
                 J[i, j] = (
-                    masses[(i-1) % masseslength + 1] + 2 * sum([1 / (x[i] - x[j])^3 for j in 1:(i - 1)]) - 2 * sum([1 / (x[i] - x[j])^3 for j in (i + 1):N])
+                    masses[(i - 1) % masseslength + 1] +
+                    2 * sum([1 / (x[i] - x[j])^3 for j in 1:(i - 1)]) -
+                    2 * sum([1 / (x[i] - x[j])^3 for j in (i + 1):N])
                 )
             else
                 J[i, j] = (
@@ -65,9 +72,12 @@ function linear_equilibrium_positions(N::Int, masslist::NTuple{num, Real} = (1.0
         initial_x =
             [(2.018 / N^0.559) * i for i in filter(x -> x ≠ 0, collect((-N ÷ 2):(N ÷ 2)))]
     end
-    sol = nlsolve((F, x) -> f!(F, x, N, relativemasslist, masslistlength),
-                  (J, x) -> j!(J, x, N, relativemasslist, masslistlength),
-                   initial_x, method = :newton)
+    sol = nlsolve(
+        (F, x) -> f!(F, x, N, relativemasslist, masslistlength),
+        (J, x) -> j!(J, x, N, relativemasslist, masslistlength),
+        initial_x,
+        method = :newton
+    )
     return sol.zero
 end
 

--- a/test/test_ion_configurations.jl
+++ b/test/test_ion_configurations.jl
@@ -83,6 +83,8 @@ using Suppressor
         # this is bad behavior and our approach does not account for it.
         # we should probably make this not happen.
         out = linear_equilibrium_positions(11, (1, 20))
+        @test sort(out) == out
+        out = linear_equilibrium_positions(11, (1, 25))
         @test sort(out) != out
     end
 end  # end suppress

--- a/test/test_ion_configurations.jl
+++ b/test/test_ion_configurations.jl
@@ -77,12 +77,12 @@ using Suppressor
         # this isn't verified data, I just tried the code out
         posL = [-2.5296, -1.6704, -1.1011, -0.5298]
         pos = [posL; 0; -1 .* reverse(posL)]
-        @test any(isapprox.(linear_equilibrium_positions(11, (1, 2)), pos, rtol = 1e-4))
+        @test any(isapprox.(linear_equilibrium_positions(9, (1, 2)), pos, rtol = 1e-4))
 
         # sometimes, too big a difference in the ions cause the solution to "flip".
         # this is bad behavior and our approach does not account for it.
         # we should probably make this not happen.
         out = linear_equilibrium_positions(11, (1, 20))
-        @test sort(test) != test
+        @test sort(out) != out
     end
 end  # end suppress

--- a/test/test_ion_configurations.jl
+++ b/test/test_ion_configurations.jl
@@ -72,4 +72,17 @@ using Suppressor
         IonSim._sparsify!(x, 2e-6)
         @test any(x .== [0, 1e-5])
     end
+
+    @testset "ion_configurations -- heterogeneous" begin
+        # this isn't verified data, I just tried the code out
+        posL = [-2.5296, -1.6704, -1.1011, -0.5298]
+        pos = [posL; 0; -1 .* reverse(posL)]
+        @test any(isapprox.(linear_equilibrium_positions(11, (1, 2)), pos, rtol = 1e-4))
+
+        # sometimes, too big a difference in the ions cause the solution to "flip".
+        # this is bad behavior and our approach does not account for it.
+        # we should probably make this not happen.
+        out = linear_equilibrium_positions(11, (1, 20))
+        @test sort(test) != test
+    end
 end  # end suppress


### PR DESCRIPTION
Please double check my work.

I rederived from the reference linked, and it looks like if $\ell = \ell_1$, then the first $u_m$ term is offset by a factor of $M_m/M_1$.

It seems to work, but I have some questions:
1. I dont know of any known examples. Can we verify this against known data?
2. When the mass differences are too much, the ions are no longer in order. But then this is very wrong; and the equations would be wrong too. Perhaps we can call an error in this case?